### PR TITLE
nbclassic 0.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,10 @@ build:
   skip: True  # [s390x or py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
-    - jupyter-bundlerextension = nbclassic.bundler.bundlerextensions:main
     - jupyter-nbclassic = nbclassic.notebookapp:main
-    - jupyter-nbextension = nbclassic.nbextensions:main
-    - jupyter-serverextension = nbclassic.serverextensions:main
+    - jupyter-nbclassic-extension = nbclassic.nbextensions:main
+    - jupyter-nbclassic-serverextension = nbclassic.serverextensions:main
+    - jupyter-nbclassic-bundlerextension = nbclassic.bundler.bundlerextensions:main
 
 requirements:
   host:
@@ -55,9 +55,9 @@ test:
   commands:
     - pip check
     - jupyter nbclassic --help
-    - jupyter nbextension --help
-    - jupyter serverextension --help
-    - jupyter bundlerextension --help
+    - jupyter nbclassic-extension --help
+    - jupyter nbclassic-serverextension --help
+    - jupyter nbclassic-bundlerextension --help
     - jupyter server extension list
     - jupyter server extension list 1>server_extensions 2>&1
     - cat server_extensions | grep -iE "nbclassic.*enabled"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,10 +64,10 @@ test:
     - cat server_extensions | grep -iE "nbclassic.*OK"
     - cat server_extensions | grep -iE "notebook_shim.*enabled"
     - cat server_extensions | grep -iE "notebook_shim.*OK"
-  downstreams:
-    - jupyterlab
-    - jupyterlab_server
-    - notebook
+  #downstreams:
+  #  - jupyterlab
+  #  - jupyterlab_server
+  #  - notebook
 
 about:
   home: https://github.com/jupyter/nbclassic

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [s390x or py<37]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - jupyter-nbclassic = nbclassic.notebookapp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "nbclassic" %}
-{% set version = "0.4.3" %}
+{% set version = "0.4.8" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f03111b2cebaa69b88370a7b23b19b2b37c9bb71767f1828cdfd7a047eae8edd
+  sha256: c74d8a500f8e058d46b576a41e5bc640711e1032cf7541dde5f73ea49497e283
 
 build:
   number: 0
@@ -22,7 +22,7 @@ build:
 requirements:
   host:
     - babel
-    - jupyter-packaging >=0.9,<2
+    - jupyter-packaging
     - python
     - pip
     - setuptools
@@ -35,7 +35,7 @@ requirements:
     - jinja2
     - jupyter_client >=6.1.1
     - jupyter_core >=4.6.1
-    - jupyter_server >=1.8
+    - jupyter_server >=1.17.0
     - nbconvert >=5
     - nbformat
     - nest-asyncio >=1.5
@@ -66,9 +66,11 @@ test:
     - cat server_extensions | grep -iE "notebook_shim.*OK"
   downstreams:
     - jupyterlab
+    - jupyterlab_server
+    - notebook
 
 about:
-  home: https://github.com/jupyterlab/nbclassic
+  home: https://github.com/jupyter/nbclassic
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -79,8 +81,8 @@ about:
     switch to Jupyter Server for their Python Web application backend. Using
     this package, users can launch Jupyter Notebook, JupyterLab and other
     frontends side-by-side on top of the new Python server backend.
-  dev_url: https://github.com/jupyterlab/nbclassic
-  doc_url: https://github.com/jupyterlab/nbclassic/blob/main/README.md
+  dev_url: https://github.com/jupyter/nbclassic
+  doc_url: https://github.com/jupyter/nbclassic/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbclassic" %}
-{% set version = "0.3.5" %}
+{% set version = "0.4.3" %}
 
 package:
   name: {{ name }}
@@ -7,27 +7,45 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 99444dd63103af23c788d9b5172992f12caf8c3098dd5a35c787f0df31490c29
+  sha256: f03111b2cebaa69b88370a7b23b19b2b37c9bb71767f1828cdfd7a047eae8edd
 
 build:
   number: 0
-  noarch: python
-  skip: True  # [s390x]
+  skip: True  # [s390x or py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
+    - jupyter-bundlerextension = nbclassic.bundler.bundlerextensions:main
     - jupyter-nbclassic = nbclassic.notebookapp:main
+    - jupyter-nbextension = nbclassic.nbextensions:main
+    - jupyter-serverextension = nbclassic.serverextensions:main
 
 requirements:
   host:
-    - jupyter-packaging >=0.9,<1
+    - babel
+    - jupyter-packaging >=0.9,<2
     - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
-    - jupyter_server >=1.8.0,<2.0.0
-    - notebook <7
+    - python
+    - argon2-cffi
+    - ipykernel
+    - ipython_genutils
+    - jinja2
+    - jupyter_client >=6.1.1
+    - jupyter_core >=4.6.1
+    - jupyter_server >=1.8
+    - nbconvert >=5
+    - nbformat
+    - nest-asyncio >=1.5
+    - notebook-shim >=0.1.0
+    - prometheus_client
+    - pyzmq >=17
+    - send2trash >=1.8.0
+    - terminado >=0.8.3
+    - tornado >=6.1
+    - traitlets >=4.2.1
 
 test:
   imports:
@@ -37,11 +55,20 @@ test:
   commands:
     - pip check
     - jupyter nbclassic --help
+    - jupyter nbextension --help
+    - jupyter serverextension --help
+    - jupyter bundlerextension --help
+    - jupyter server extension list
+    - jupyter server extension list 1>server_extensions 2>&1
+    - cat server_extensions | grep -iE "nbclassic.*enabled"
+    - cat server_extensions | grep -iE "nbclassic.*OK"
+    - cat server_extensions | grep -iE "notebook_shim.*enabled"
+    - cat server_extensions | grep -iE "notebook_shim.*OK"
   downstreams:
     - jupyterlab
 
 about:
-  home: http://github.com/jupyterlab/nbclassic
+  home: https://github.com/jupyterlab/nbclassic
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
**Jira ticket:** [PKG-300](https://anaconda.atlassian.net/browse/PKG-300) (nbclassic-0.4.8)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/nbclassic/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/nbclassic/compare/0.3.5...0.4.8)
License: https://github.com/jupyterlab/nbclassic/blob/master/LICENSE
Changelog: https://github.com/jupyterlab/nbclassic/blob/main/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/jupyterlab/nbclassic/blob/v0.4.8/setup.cfg
 * setup.py:  https://github.com/jupyterlab/nbclassic/blob/v0.4.8/setup.py
 *  pyproject.toml:  https://github.com/jupyterlab/nbclassic/blob/v0.4.8/pyproject.toml

**_Actions:_**

1. Add new `entry_points`
2. Update `host` dependencies: add `babel`, remove pinning for `jupyter-packaging`
3. Update `run` dependencies
4. Add new `test/commands`
5. Update `home` url, `doc_url`, & `dev_url` 

**_Notes:_**
 * It depends on `notebook-shim` https://github.com/AnacondaRecipes/notebook-shim-feedstock/pull/1
 * Downstream packages passed tests:  `jupyterlab`, `jupyterlab_server`, and `notebook`
 * We need to rebuild `notebook` package

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.4.8
 * Release on PyPi:
    * version: 0.4.8
    * date: 2022-11-03T11:14:44
* [PyPi history](https://pypi.org/project/nbclassic/#history)
 * Popularity: 
    * 3 months downloads: 430803.0
    * All time:  2203101 downloads -  nbclassic  0.4.8  A web-based notebook environment for interactive computing  copy  

</details>

**Other checks:**

<details>

1. - [x] The upstream url:
    https://github.com/jupyter/nbclassic/tree/0.4.8
7. - [x] Check the pinnings
9. - [x] Additional research
    https://github.com/jupyter/nbclassic/issues
10. - [x] `dev_url`:
    https://github.com/jupyter/nbclassic
11. - [x] `doc_url`:
    https://github.com/jupyter/nbclassic/blob/main/README.md
12. - [x] Verify that the `build_number` is correct
13. - [x] has `setuptools`
14. - [x] has `wheel`
15. - [x] `pip` in test
16. - [x] Verify the test section
17. - [x] Verify if the package is `architecture specific`
18. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
19.  - [x] license_file: LICENSE is present
20. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

21. - [x] license_family BSD is present
</details>

