### PR TITLE
nbclassic 0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbclassic" %}
-{% set version = "0.4.8" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c74d8a500f8e058d46b576a41e5bc640711e1032cf7541dde5f73ea49497e283
+  sha256: 40f11bbcc59e8956c3d5ef132dec8e5a853e893ecf831e791d54da0d8a50d79d
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 970e851..7f5d1d2 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbclassic" %}
-{% set version = "0.4.8" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c74d8a500f8e058d46b576a41e5bc640711e1032cf7541dde5f73ea49497e283
+  sha256: 40f11bbcc59e8956c3d5ef132dec8e5a853e893ecf831e791d54da0d8a50d79d
 
 build:
   number: 0

```

**Jira ticket:** [PKG-1054
PKG-300](https://anaconda.atlassian.net/browse/PKG-1054
https://anaconda.atlassian.net/browse/PKG-300) (nbclassic
nbclassic-0.5.1
0.4.8)

**The upstream data:**
Github releases:  https://github.com/jupyter/nbclassic/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/nbclassic/compare/0.4.8...0.5.2)
Changelog: https://github.com/jupyter/nbclassic/blob/main/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/jupyter/nbclassic/blob/v0.5.2/setup.cfg
 * setup.py:  https://github.com/jupyter/nbclassic/blob/v0.5.2/setup.py
 *  pyproject.toml:  https://github.com/jupyter/nbclassic/blob/v0.5.2/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.5.2
 * Release on PyPi:
    * version: 0.5.2
    * date: 2023-02-18T09:13:21
* [PyPi history](https://pypi.org/project/nbclassic/#history)
 * Popularity: 
    * 3 months downloads: 1015071.0
    * All time:  3223642 downloads -  nbclassic  0.5.2  A web-based notebook environment for interactive computing  copy  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check GUI app:**

<details>
**GUI app check**

Recommend to make testing in c3i_test2 channel!
../aggregate/nbclassic is a GUI aplication

**End GUI check**

</details>

**Check dependency issues:**

<details>
../aggregate/nbclassic-feedstock/recipe/meta.yaml
Dependencies: ['terminado >=0.8.3', 'ipython_genutils', 'prometheus_client', 'jupyter_server >=1.17.0', 'nbformat', 'jupyter_client >=6.1.1', 'send2trash >=1.8.0', 'jupyter_core >=4.6.1', 'pyzmq >=17', 'nbconvert >=5', 'wheel', 'tornado >=6.1', 'jupyter-packaging', 'ipykernel', 'pip', 'argon2-cffi', 'notebook-shim >=0.1.0', 'babel', 'jinja2', 'nest-asyncio >=1.5', 'traitlets >=4.2.1', 'python', 'setuptools']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/nbclassic-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/nbclassic-feedstock/tree/0.5.2)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/nbclassic)
* [Diff between upstream and feature branch](https://github.com/conda-forge/nbclassic-feedstock/compare/main...AnacondaRecipes:0.5.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/nbclassic-feedstock/compare/master...AnacondaRecipes:0.5.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/nbclassic-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.5.2 git@github.com:AnacondaRecipes/nbclassic-feedstock.git
```
