### PR TITLE
update to 0.5.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nbclassic" %}
-{% set version = "0.5.4" %}
-{% set sha256 = "312b3f7d7ff2e6c261d51799bb12e6493498ab47d3469d3a01015d5533fd4d2b" %}
+{% set version = "0.5.5" %}
+{% set sha256 = "d2c91adc7909b0270c73e3e253d3687a6704b4f0a94bc156a37c85eba09f4d37" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
update nbclassic 0.5.4 -> 0.5.5
- jira: [PKG-1546](https://anaconda.atlassian.net/browse/PKG-1546)
- all deps remain the same, checked with upstream

[PKG-1546]: https://anaconda.atlassian.net/browse/PKG-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ